### PR TITLE
Fix flink conf quotes

### DIFF
--- a/templates/flink-conf.yaml.j2
+++ b/templates/flink-conf.yaml.j2
@@ -157,5 +157,5 @@ env.pid.dir: {{flink_env_pid_dir}}
 {% endif %}
 
 {% for key, value in flink_other_config.iteritems() %}
-"{{key}}": {{value}}
+{{key}}: {{value}}
 {% endfor %}


### PR DESCRIPTION
Quotes are not needed for the extra config